### PR TITLE
fix(InputService): Enforce min and max when clearing value

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -89,7 +89,7 @@ export class InputService {
         let onlyNumbers = rawValue.replace(this.ONLY_NUMBERS_REGEX, "");
 
         if (!onlyNumbers && rawValue !== decimal) {
-            return "";
+            return this.options.nullable ? "" : this.applyMask(true, '0');
         }
 
         if (inputMode === CurrencyMaskInputMode.NATURAL && !isNumber && !disablePadAndTrim) {

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -589,6 +589,140 @@ describe('Testing InputService', () => {
 
       expect(inputService.applyMask(false, ',')).to.be.equal('0,00');
     });
+
+    describe('with no numbers present', () => {
+      describe('when nullable == true', () => { 
+        it('should return empty string if min/max not specified', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: true,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('');
+        });
+
+        it('should return empty string even if min/max is specified', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: true,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+            min: 1,
+            max: 10,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('');
+        });
+      });
+
+      describe('when nullable == false', () => { 
+        it('should return 0 if min/max not specified', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: false,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('$ 0');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('$ 0');
+        });
+
+        it('should return 0 if min/max is specified and 0 is in range', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: false,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+            min: -10,
+            max: 10,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('$ 0');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('$ 0');
+        });
+
+        it('should return min if min/max is specified and min > 0', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: false,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+            min: 5,
+            max: 10,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('$ 5');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('$ 5');
+        });
+
+        it('should return max if min/max is specified max < 0', () => {
+          options = {
+            prefix: '$ ',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: true,
+            nullable: false,
+            align: 'right',
+            allowZero: true,
+            precision: 0,
+            min: -10,
+            max: -5,
+          };
+          inputService = new InputService({
+            selectionStart: 0,
+            selectionEnd: 0,
+          }, options);   
+          expect(inputService.applyMask(false, '')).to.be.equal('-$ 5');
+          expect(inputService.applyMask(false, '$ ')).to.be.equal('-$ 5');
+        });
+      });
+    });
   });
 
   describe('padOrTrimPrecision', () => {


### PR DESCRIPTION
Currently, clearing the input field of all numbers (eg. by backspacing the only digit)
while nullable==false will coerce the value to 0, even if you specified a min/max range
that doesn't include 0.

For example, if nullable = false, min = 5, max = 10, then deleting the
only digit will result in the value 0 instead of 5.  This only seems to happen when precision
is set to 0 (aka no decimal). This changes coerces the value to be within the min/max range.

Current Behavior when clearing the input:

|   | nullable == true | nullable == false |
| - | - | - |
| min/max not specified | null | always 0 (correct) |
| min or max specified  | null | always 0 (wrong) |

New Bahvior:

| | nullable == true | nullable == false |
| - | - | - |
| min/max not specified | null | always 0 (correct) |
| min or max specified | null | 0 if in range, otherwise the closest number in range (usually min, but could be max if the range is entirely negative) |